### PR TITLE
Add spinner when loading page insights.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "bard",
   "version": "0.0.1",
   "description": "Bard - Telling the story of Facebook page performance.",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/guardian/bard.git"
+  },
   "dependencies": {
     "babel-core": "^6.0.20",
     "babel-loader": "^6.0.1",
@@ -19,6 +23,7 @@
     "react-chartist": "^0.10.2",
     "react-dom": "^0.14.8",
     "react-router": "^1.0.0",
+    "react-loader": "^2.4.0",
     "reqwest": "^2.0.5",
     "webpack": "^1.12.11"
   },

--- a/public/components/pageInsightsController.react.js
+++ b/public/components/pageInsightsController.react.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Page from './page.react';
 import PageInsightsService from '../services/PageInsightsService';
+import Loader from 'react-loader';
 
 export default class PageInsightsController extends React.Component {
 
@@ -8,6 +9,7 @@ export default class PageInsightsController extends React.Component {
         super(props);
 
         this.state = {
+            loaded: false,
             pageInsightsData: undefined
         }
     }
@@ -23,16 +25,23 @@ export default class PageInsightsController extends React.Component {
     }
 
     loadPageInsights(page, from, to) {
+        /* Means spinner will show when changing between page insight pages. */
+        this.setState({loaded: false, pageInsightsData: this.state.pageInsightsData});
         PageInsightsService.getPageInsights(page, from, to).then( response => {
-            this.setState({pageInsightsData: response});
+            this.setState({loaded: true, pageInsightsData: response});
         });
     }
 
     render() {
-        if (!this.state.pageInsightsData) { return false };
-
         return (
-            <Page data={this.state.pageInsightsData} />
+            <Loader loaded={this.state.loaded} lines={13} length={20} width={10} radius={30}
+                corners={1} rotate={0} direction={1} color="#000" speed={1}
+                trail={60} shadow={false} hwaccel={false} className="spinner"
+                zIndex={2e9} top="50%" left="50%" scale={1.00}
+                loadedClassName="loadedContent" >
+
+                <Page data={this.state.pageInsightsData} />
+            </Loader>
         );
     }
 }


### PR DESCRIPTION
This is needed as the initial request for a specfic page with its from and to parameters will hit the
    FB api directly and not benefit from server side caching. Therefore this shows the user that something is actually happening.