### PR TITLE
Add total page video views metrics.

### DIFF
--- a/app/com/gu/bard/metrics/PageInsightGraphs.scala
+++ b/app/com/gu/bard/metrics/PageInsightGraphs.scala
@@ -52,6 +52,16 @@ class PageInsightGraphs(graphSettingsMap: Map[String, GraphSettings], val metric
       getGraph(graphSettingsMap.get(GraphSettingsKey), "SUM")
     }
 
+    def pageVideoViewsTotalAndUnique: Option[Graph] = {
+      val GraphSettingsKey = "totalPageVideoViewsAndUnique"
+      getGraph(graphSettingsMap.get(GraphSettingsKey), "SUM")
+    }
+
+    def pageVideoViewsComplete10sAnd30sTotalAndUnique: Option[Graph] = {
+      val GraphSettingsKey = "totalPageVideoViewsComplete10sAnd30sAndUnique"
+      getGraph(graphSettingsMap.get(GraphSettingsKey), "SUM")
+    }
+
   }
 
 }

--- a/app/com/gu/bard/services/PageService.scala
+++ b/app/com/gu/bard/services/PageService.scala
@@ -52,6 +52,8 @@ object PageService {
           postGraphs.totalPostsPerDay,
           pageInsightsGraphsForDay.combinedGraphs.totalNewPeopleWhoLikeAndUnlike,
           pageInsightsGraphsForDay.combinedGraphs.postsImpressionsTotalAndUnique,
+          pageInsightsGraphsForDay.combinedGraphs.pageVideoViewsTotalAndUnique,
+          pageInsightsGraphsForDay.combinedGraphs.pageVideoViewsComplete10sAnd30sTotalAndUnique,
           pageInsightsGraphsForDay.totalPostLikeReactions
         ).flatten
       )

--- a/app/com/gu/bard/settings/MetricSettings.scala
+++ b/app/com/gu/bard/settings/MetricSettings.scala
@@ -46,4 +46,34 @@ object MetricSettings {
     fbMetricName = "page_fans"
   )
 
+  def totalPageVideoViews = MetricSettings(
+    metricType = "content_effectiveness",
+    fbMetricName = "page_video_views"
+  )
+
+  def totalPageVideoViewsUnique = MetricSettings(
+    metricType = "content_effectiveness",
+    fbMetricName = "page_video_views_unique"
+  )
+
+  def totalPageVideoCompleteViews30s = MetricSettings(
+    metricType = "content_effectiveness",
+    fbMetricName = "page_video_complete_views_30s"
+  )
+
+  def totalPageVideoCompleteViews30sUnique = MetricSettings(
+    metricType = "content_effectiveness",
+    fbMetricName = "page_video_complete_views_30s_unique"
+  )
+
+  def totalPageVideoCompleteViews10s = MetricSettings(
+    metricType = "content_effectiveness",
+    fbMetricName = "page_video_views_10s"
+  )
+
+  def totalPageVideoCompleteViews10sUnique = MetricSettings(
+    metricType = "content_effectiveness",
+    fbMetricName = "page_video_views_10s_unique"
+  )
+
 }

--- a/app/com/gu/bard/settings/PageInsightsPageSettings.scala
+++ b/app/com/gu/bard/settings/PageInsightsPageSettings.scala
@@ -49,6 +49,29 @@ object PageInsightsPageSettings {
       axisXLabel = "Date",
       axisYLabel = "No of Fans",
       Seq(MetricSettings.totalPageFans)
+    ),
+    "totalPageVideoViewsAndUnique" -> GraphSettings(
+      title = "Total number of page video views",
+      description = "Total number of times videos have been viewed for more than 3 seconds.",
+      whatsSuccess = " ... ",
+      `type` = "line",
+      axisXLabel = "Date",
+      axisYLabel = "No of views",
+      Seq(MetricSettings.totalPageVideoViews, MetricSettings.totalPageVideoViewsUnique)
+    ),
+    "totalPageVideoViewsComplete10sAnd30sAndUnique" -> GraphSettings(
+      title = "Total number of page video views (breakdown by view duration)",
+      description = "Total number of times page's videos was viewed for at least 10 or 30 seconds.",
+      whatsSuccess = " ... ",
+      `type` = "bar",
+      axisXLabel = "Date",
+      axisYLabel = "No of views",
+      Seq(
+        MetricSettings.totalPageVideoCompleteViews30s,
+        MetricSettings.totalPageVideoCompleteViews30sUnique,
+        MetricSettings.totalPageVideoCompleteViews10s,
+        MetricSettings.totalPageVideoCompleteViews10sUnique
+      )
     )
   )
 


### PR DESCRIPTION
This PR adds graphs for:

 - Total page video views (for at least three seconds)
 - Total page video views for videos viewed for at least 10 and 30 seconds. These are displayed against each other on the same graph as a barchart.