### PR TITLE
Bard - Scala apps should not be on t2.nano.

### DIFF
--- a/bard.service
+++ b/bard.service
@@ -6,7 +6,7 @@ User=content-api
 Group=content-api
 Restart=on-failure
 Environment='HOME=/home/content-api'
-Environment='JAVA_OPTS=-Xms256m -Xmx256m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:ReservedCodeCacheSize=256m'
+Environment='JAVA_OPTS=-Xmx512m -Xms512m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:ReservedCodeCacheSize=256m'
 WorkingDirectory=/home/content-api
 ExecStart=/home/content-api/bard/bin/bard
 

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -117,7 +117,7 @@ Resources:
             AssociatePublicIpAddress: true
             SecurityGroups:
                 - !Ref ApplicationSecurityGroup
-            InstanceType: t2.nano
+            InstanceType: t2.micro
             IamInstanceProfile: !Ref InstanceProfile
             UserData:
                 Fn::Base64:


### PR DESCRIPTION
- Move to t2.micro
 - Give jvm more memory.